### PR TITLE
fix: export config-code-blocks function

### DIFF
--- a/examples/code.typ
+++ b/examples/code.typ
@@ -1,0 +1,11 @@
+#import "/src/lib.typ": config-code-blocks, flavors
+
+#show: config-code-blocks.with(flavors.latte)
+
+Using catppuccin for syntax highlighting:
+
+```typ
+#import "@preview/catppuccin:1.0.1": config-code-blocks, flavors
+#show: config-code-blocks.with(flavors.mocha)
+```
+

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -1,5 +1,5 @@
 #import "version.typ": version
-#import "catppuccin.typ": catppuccin
+#import "catppuccin.typ": catppuccin, config-code-blocks
 #import "flavors.typ": (
   color-names, flavors, frappe, get-flavor, get-or-validate-flavor, latte,
   macchiato, mocha,


### PR DESCRIPTION
Export `config-code-blocks` so it can be used without changing the whole document to Catppuccin theme.